### PR TITLE
Corrected link from 2008 to 2015

### DIFF
--- a/android/src/net/sf/openrocket/android/thrustcurve/SearchResponseParser.java
+++ b/android/src/net/sf/openrocket/android/thrustcurve/SearchResponseParser.java
@@ -13,7 +13,7 @@ import android.util.Xml;
 
 public class SearchResponseParser {
 
-	private static final String thrustcurveURI = "http://www.thrustcurve.org/2008/SearchResponse";
+	private static final String thrustcurveURI = "http://www.thrustcurve.org/2015/SearchResponse";
 	/*
 	 * XML Tags in SearchResult xsd
 	 */


### PR DESCRIPTION
Causes an error in android "Root element name does not match".